### PR TITLE
Bug/Extension of  the tour to three complicated settings on the dashboard #134061759

### DIFF
--- a/client/introCustomStyle.css
+++ b/client/introCustomStyle.css
@@ -1,3 +1,7 @@
 .introjs-helperNumberLayer {
     display: none;
 }
+
+.introjs-helperLayer{
+    background-color: rgba(-5, -5, 1, 0.3) !important;
+}

--- a/client/modules/accounts/templates/dropdown/dropdown.html
+++ b/client/modules/accounts/templates/dropdown/dropdown.html
@@ -45,6 +45,14 @@
         </a>
       </li>
     {{/each}}
+    <!-- Take Tour shortcut -->
+    <li class="dropdown-apps-icon">
+       <a onclick="javascript:introJs().start();">  
+         <i class="fa fa-info-circle"></i>
+         <span class="icon-text">Take Tour </span>
+      </a>
+    </li>
+   
   </ul>
 </template>
 

--- a/client/modules/i18n/templates/i18nSettings.html
+++ b/client/modules/i18n/templates/i18nSettings.html
@@ -1,11 +1,20 @@
 <template name="i18nSettings">
+  <div class="i18nSettings" id="internalization-settings">   
   <div class="panel panel-default">
+    <div class="panel-heading">
+       <button type="button" class="btn btn-success" onclick="runInternationalizationTour()">Take Tour</button> 
+    </div>
+    <script>
+      function runInternationalizationTour() {
+         introJs("#internalization-settings").start();    
+      } 
+   </script>
     <div class="panel-body">
       {{#autoForm collection=Collections.Shops doc=shop id="shopEditLocalizationSettingsForm" type="update" autosave=true}}
-        {{> afQuickField name='timezone' options=timezoneOptions}}
-        {{> afQuickField name='currency' options=currencyOptions}}
-        {{> afQuickField name='baseUOM' options=uomOptions}}
-        {{> afQuickField name='language' options=enabledLanguages}}
+        {{> afQuickField name='timezone' options=timezoneOptions data-intro="Set your time zone" data-position="auto"}}
+        {{> afQuickField name='currency' options=currencyOptions data-intro="Set your default currency" data-position="auto"}}
+        {{> afQuickField name='baseUOM' options=uomOptions data-intro="Set your default unit of measure" data-position="auto"}}
+        {{> afQuickField name='language' options=enabledLanguages data-intro="Set your default language. Users can change this for their use" data-position="auto"}}
       {{/autoForm}}
     </div>
     <div class="panel-body">
@@ -22,6 +31,7 @@
         </div>
       {{/each}}
     </div>
+  </div>
   </div>
 
 </template>

--- a/client/modules/i18n/templates/i18nSettings.js
+++ b/client/modules/i18n/templates/i18nSettings.js
@@ -1,7 +1,7 @@
 import i18next from "i18next";
 import { Countries } from "/client/collections";
 import { Reaction } from "/client/api";
-import { Shops } from "/lib/collections";
+import { Shops, Accounts } from "/lib/collections";
 import { Meteor } from "meteor/meteor";
 import { Template } from "meteor/templating";
 
@@ -100,3 +100,27 @@ AutoForm.hooks({
     }
   }
 });
+
+Template.i18nSettings.events({
+  'mouseenter .i18nSettings'(){
+
+    const currentUser = Accounts.findOne(Meteor.userId());
+    const myintro = introJs("#internalization-settings");
+
+    if(Meteor.user().emails.length > 0 && !currentUser.i18nSettingsTour){
+      myintro.start();
+    }
+
+    myintro.oncomplete(function() { 
+      Accounts.update({_id: Meteor.userId()}, {$set:{i18nSettingsTour: true}}, function (error, res) {
+      });
+        
+      });
+  },
+
+  'mouseleave .i18nSettings'(){
+     const myintro = introJs("#internalization-settings");
+     myintro.exit();
+  },
+
+})

--- a/imports/plugins/core/dashboard/client/templates/dashboard.html
+++ b/imports/plugins/core/dashboard/client/templates/dashboard.html
@@ -20,11 +20,6 @@
              
              {{i18n i18nKeyTitle label}}
 
-             {{#if labelIs "Core"}}
-              <em class="small">
-                <a href="javascript:void(0);" onclick="javascript:introJs().start();" style="color:blue">Take Dashboard Tour</a>
-              </em>
-            {{/if}}
            </span>
           {{/with}}
         </div>

--- a/imports/plugins/core/dashboard/client/templates/dashboard.js
+++ b/imports/plugins/core/dashboard/client/templates/dashboard.js
@@ -13,11 +13,6 @@ Template.dashboardHeader.helpers({
       return Reaction.translateRegistry(registry);
     }
   },
-
-  labelIs (label) {
-    const registry = Reaction.getRegistryForCurrentRoute() || {};
-    return registry.label === label;
-  }
 });
 
 //

--- a/imports/plugins/core/dashboard/client/templates/packages/grid/grid.html
+++ b/imports/plugins/core/dashboard/client/templates/packages/grid/grid.html
@@ -2,7 +2,7 @@
   <div class="rui items">
     {{#each group in groups}}
       <div class="rui item">
-        {{#cardGroup title=group step=@index intro=messages}}
+        {{#cardGroup title=group }}
           {{> packagesGridGroup apps=(appsInGroup group)}}
         {{/cardGroup}}
       </div>

--- a/imports/plugins/core/dashboard/client/templates/packages/grid/grid.js
+++ b/imports/plugins/core/dashboard/client/templates/packages/grid/grid.js
@@ -98,18 +98,6 @@ Template.packagesGrid.helpers({
     return group;
   },
 
-  messages() {
-    const introMessages = [
-      "This is your core settings",
-      "Below is your utilities settings",
-      "Followed next when you scroll is your appearance settings",
-      "Scroll next is your connect settings",
-      "And finally your payment method settings"
-    ];
-
-    return introMessages;
-  },
-
   appsInGroup(groupName) {
     const group = Template.instance().state.get("appsByGroup") || {};
     return group[groupName] || false;
@@ -138,12 +126,4 @@ Template.packagesGridGroup.helpers({
       }
     };
   }
-});
-
-Template.registerHelper("groupIndex", function (i) {
-  return i + 14;
-});
-
-Template.registerHelper('introMsg', function(msg, i){
-  return msg[i];
 });

--- a/imports/plugins/core/dashboard/client/templates/shop/settings/settings.html
+++ b/imports/plugins/core/dashboard/client/templates/shop/settings/settings.html
@@ -11,7 +11,7 @@
 
 <template name="shopSettings">
 
-  <div class="panel-group" id="shopSettingsAccordian" role="tablist" aria-multiselectable="true">
+  <div class="panel-group shopSettings" id="shopSettingsAccordian" role="tablist" aria-multiselectable="true">
     <div class="panel panel-default">
       <div class="panel-heading">
         <div class="panel-title">
@@ -25,11 +25,17 @@
             data-i18n="shopSettings.general">General</a>
         </div>
       </div>
+      <script>
+        function runCoreSettingsTour() {
+          introJs("#shopSettingsAccordian").start();
+        }
+      </script>
       <div id="general" class="panel-collapse collapse in" role="tabpanel" aria-labelledby="General">
         <div class="panel-body">
+          <button type="button" class="btn btn-success" onclick="runCoreSettingsTour()">Take Tour</button>
           {{#autoForm collection=Collections.Packages schema=Schemas.CorePackageConfig
           doc=packageData id="shopEditOptionsForm" type="update" autosave=true}}
-            {{> afFieldInput name='settings.public.allowGuestCheckout'}}
+            {{> afFieldInput name='settings.public.allowGuestCheckout' data-intro="Allow or stop guests from checking out" data-position="auto"}}
           {{/autoForm}}
         </div>
         <div class="panel-body">
@@ -38,10 +44,10 @@
         </div>
         <div class="panel-body">
           {{#autoForm collection=Collections.Shops doc=shop id="shopEditForm" type="update"}}
-            {{> afQuickField name='name' placeholder="Shop Name"}}
-            {{> afQuickField name='emails.0.address' label="Email" placeholder="Primary Contact Email"}}
-            {{> afQuickField name='description' placeholder="Description"}}
-            {{> afQuickField name='keywords' placeholder="Keywords"}}
+            {{> afQuickField name='name' placeholder="Shop Name" data-intro="Customize your store name" data-position="auto"}}
+            {{> afQuickField name='emails.0.address' label="Email" placeholder="Primary Contact Email" data-intro="Set the primary contact email address" data-position="auto"}}
+            {{> afQuickField name='description' placeholder="Description" data-intro="Add a description to your store" data-position="auto"}}
+            {{> afQuickField name='keywords' placeholder="Keywords" data-intro="Keywords make your store more visible. Add some" data-position="auto"}}
             {{> shopSettingsSubmitButton}}
           {{/autoForm}}
         </div>

--- a/imports/plugins/core/dashboard/client/templates/shop/settings/settings.js
+++ b/imports/plugins/core/dashboard/client/templates/shop/settings/settings.js
@@ -1,6 +1,6 @@
 import _ from "lodash";
 import { Reaction, i18next } from "/client/api";
-import { Media, Packages, Shops } from "/lib/collections";
+import { Media, Packages, Shops, Accounts } from "/lib/collections";
 
 Template.shopBrandImageOption.helpers({
   cardProps(data) {
@@ -228,3 +228,27 @@ AutoForm.hooks({
     }
   }
 });
+
+Template.shopSettings.events({
+  'mouseenter .shopSettings'(){
+
+    const currentUser = Accounts.findOne(Meteor.userId());
+    const myintro = introJs("#shopSettingsAccordian");
+
+    if(Meteor.user().emails.length > 0 && !currentUser.shopSettingsTour){
+      myintro.start();
+    }
+
+    myintro.oncomplete(function() { 
+      Accounts.update({_id: Meteor.userId()}, {$set:{shopSettingsTour: true}}, function (error, res) {
+      });
+        
+      });
+  },
+
+  'mouseleave .shopSettings'(){
+     const myintro = introJs("#shopSettingsAccordian");
+     myintro.exit();
+  },
+
+})

--- a/imports/plugins/core/layout/client/templates/layout/admin/admin.html
+++ b/imports/plugins/core/layout/client/templates/layout/admin/admin.html
@@ -50,7 +50,7 @@
 
   <div class="admin-controls-menu">
 
-    <nav class="admin-controls-quicklinks" data-step="1" data-intro="Click here to manage your store">
+    <nav class="admin-controls-quicklinks">
       {{!-- Reaction.Apps provides=shortcut --}}
       {{#each props in shortcutButtons}}
         {{#if isSeperator props}}

--- a/imports/plugins/core/layout/client/templates/layout/admin/admin.js
+++ b/imports/plugins/core/layout/client/templates/layout/admin/admin.js
@@ -41,7 +41,7 @@ Template.coreAdminLayout.helpers({
           tooltip: shortcuts[i].label || "",
           i18nKeyTooltip: shortcuts[i].i18nKeyLabel,
           tooltipPosition: "left middle",
-          "data-step": i+1,
+          "data-step": i+7,
           "data-intro": introMessages[i],
         });
       }

--- a/imports/plugins/core/ui-navbar/client/components/navbar/navbar.html
+++ b/imports/plugins/core/ui-navbar/client/components/navbar/navbar.html
@@ -25,7 +25,6 @@
       {{> tagNav tagNavProps}}
     </div>
 
-    <div class="search"  onclick="javascript:introJs().start();">Take Tour</div>
     <div class="search searchIcon" data-step="1" data-intro="Search for products">{{> React SearchButtonComponent}}</div>
     {{#if hasPermission 'account/profile'}}
     <div class="dropdown">

--- a/imports/plugins/core/ui-navbar/client/components/navbar/navbar.html
+++ b/imports/plugins/core/ui-navbar/client/components/navbar/navbar.html
@@ -26,19 +26,22 @@
     </div>
 
     <div class="search"><a href="javascript:void(0);" onclick="javascript:introJs().start();">Take Tour</a></div>
-    <div class="search searchIcon" data-step="7" data-intro="Search for products">{{> React SearchButtonComponent}}</div>
+    <div class="search searchIcon" data-step="1" data-intro="Search for products">{{> React SearchButtonComponent}}</div>
     {{#if hasPermission 'account/profile'}}
     <div class="dropdown">
-      <div class="search dropdown-toggle" data-toggle="dropdown" data-hover="dropdown" data-delay="3000" data-step="7" data-intro="Search for products">{{> React NotificationButtonComponent}}</div>
+      <div class="search dropdown-toggle" data-toggle="dropdown" data-hover="dropdown" 
+          data-delay="3000" data-step="2" data-intro="This is your notifications icon">
+            {{> React NotificationButtonComponent}}
+      </div>
       <div class="notify-drop dropdown-menu">
         {{> React NotificationDropdownComponent}}
       </div>
     </div>
     {{/if}}
-    <div class="languages hidden-xs" data-step="6" data-intro="Select a language that suits you best">{{> i18nChooser}}</div>
+    <div class="languages hidden-xs" data-step="3" data-intro="Select a language that suits you here">{{> i18nChooser}}</div>
     {{> pages}}
-    <div class="accounts" data-step="8" data-intro="This is your account drop down menu you can fill out your profile or signout from here">{{> accounts tpl="loginDropdown"}}</div>
-    <div class="cart" data-step="9" data-intro="This is your cart you can always click here to see your ordered products">{{> cartIcon}}</div>
+    <div class="accounts" data-step="5" data-intro="This is your account drop down menu you can fill out your profile or signout from here">{{> accounts tpl="loginDropdown"}}</div>
+    <div class="cart" data-step="6" data-intro="This is your cart you can always click here to see your ordered products">{{> cartIcon}}</div>
     <div class="cart-alert">{{> cartPanel}}</div>
   </div>
 </template>
@@ -46,7 +49,7 @@
 <!--This template renders a dropdown of links to the static pages-->
 <template name="pages">
   <div class="dropdown">
-      <div class="dropdown-toggle accounts" data-toggle="dropdown" data-step="7" data-intro="This is a dropdown of links to static pages">More
+      <div class="dropdown-toggle accounts" data-toggle="dropdown" data-step="4" data-intro="This is a dropdown of links to other pages">More
       <span class="caret"></span></div>
       <ul class="dropdown-menu">
         {{#each pagesDisplay }}

--- a/imports/plugins/core/ui-navbar/client/components/navbar/navbar.html
+++ b/imports/plugins/core/ui-navbar/client/components/navbar/navbar.html
@@ -25,7 +25,7 @@
       {{> tagNav tagNavProps}}
     </div>
 
-    <div class="search"><a href="javascript:void(0);" onclick="javascript:introJs().start();">Take Tour</a></div>
+    <div class="search"  onclick="javascript:introJs().start();">Take Tour</div>
     <div class="search searchIcon" data-step="1" data-intro="Search for products">{{> React SearchButtonComponent}}</div>
     {{#if hasPermission 'account/profile'}}
     <div class="dropdown">

--- a/imports/plugins/core/ui/client/components/cards/cardGroup.html
+++ b/imports/plugins/core/ui/client/components/cards/cardGroup.html
@@ -1,6 +1,5 @@
 <template name="cardGroup">
-  <div class="rui card-group" data-step="{{groupIndex step}}" 
-    data-intro="{{introMsg intro step}}" data-position="auto">
+  <div class="rui card-group">
     <div class="header">
       <span data-i18n="admin.groups.{{title}}">{{title}}</span>
     </div>

--- a/imports/plugins/included/paypal/client/templates/settings/settings.html
+++ b/imports/plugins/included/paypal/client/templates/settings/settings.html
@@ -1,62 +1,70 @@
 <template name="paypalSettings">
-
-  <div class="panel panel-default">
-    <div class="panel-heading">
-      <h3 class="panel-title">Pay with PayPal button</h3>
-    </div>
-    <div class="panel-body">
-      {{#autoForm
-        collection="ReactionCore.Collections.Packages"
-        schema=PaypalPackageConfig
-        doc=packageData
-        type="update"
-        id="paypal-update-form-express"
+  <div class="paypalTour" id="paypal-config">
+    <div class="panel panel-default">
+      <div class="panel-heading">
+        <h3 class="panel-title">Pay with PayPal button</h3>
+        <br>
+        <button type="button" class="btn btn-success" onclick="runPaypalTour()">Take Tour</button>
+      </div>
+      <script>
+        function runPaypalTour() {
+          introJs("#paypal-config").start();
+        }
+      </script>
+      <div class="panel-body">
+        {{#autoForm
+          collection="ReactionCore.Collections.Packages"
+          schema=PaypalPackageConfig
+          doc=packageData
+          type="update"
+          id="paypal-update-form-express"
         }}
 
-        <div class="form-group">
-          Don't have a PayPal username, password and signature? <a href="https://developer.paypal.com/webapps/developer/applications/accounts" target="_blank">Get one here.</a>
-        </div>
+          <div class="form-group">
+            Don't have a PayPal username, password and signature? <a
+              href="https://developer.paypal.com/webapps/developer/applications/accounts" target="_blank">Get one
+            here.</a>
+          </div>
 
-        {{>afQuickField name='settings.express_enabled' type="boolean-select" trueLabel="Enabled" falseLabel="Disabled" style="width: auto"}}
-        {{>afQuickField name="settings.express_auth_and_capture"}}
-        {{>afQuickField name='settings.merchantId'}}
-        {{>afQuickField name='settings.username'}}
-        {{>afQuickField name='settings.password' type="password"}}
-        {{>afQuickField name='settings.signature'}}
-        {{>afQuickField name='settings.express_mode' type="boolean-select" trueLabel="Live - Production Mode" falseLabel="Testing - Sandbox Mode" style="width: auto"}}
+          {{>afQuickField name='settings.express_enabled' type="boolean-select" trueLabel="Enabled" falseLabel="Disabled" style="width: auto" data-intro="Enable or disable express" data-position="auto"}}
+          {{>afQuickField name="settings.express_auth_and_capture"
+            data-intro="Set whether you should capture at auth."
+            data-position="auto"}}
+          {{>afQuickField name='settings.merchantId' data-intro="Set the merchant ID gotten from paypal" data-position="auto"}}
+          {{>afQuickField name='settings.username' data-intro="Set your username" data-position="auto"}}
+          {{>afQuickField name='settings.password' type="password" data-intro="Set your password" data-position="auto"}}
+          {{>afQuickField name='settings.signature' data-intro="Set the signature obtained from paypal" data-position="auto"}}
+          {{>afQuickField name='settings.express_mode' type="boolean-select" trueLabel="Live - Production Mode" falseLabel="Testing - Sandbox Mode" style="width: auto" data-intro="Set your express mode, whether testing or production" data-position="auto"}}
 
-        <button type="submit" class="btn btn-primary pull-right">Save Changes</button>
-      {{/autoForm}}
+          <button type="submit" class="btn btn-primary pull-right">Save Changes</button>
+        {{/autoForm}}
+      </div>
     </div>
-  </div>
 
-
-
-
-  <div class="panel panel-default">
-    <div class="panel-heading">
-      <h3 class="panel-title">Payflow Pro</h3>
-    </div>
-    <div class="panel-body">
-      {{#autoForm
-        collection="ReactionCore.Collections.Packages"
-        schema=PaypalPackageConfig
-        doc=packageData
-        type="update"
-        id="paypal-update-form-payflow"
+    <div class="panel panel-default">
+      <div class="panel-heading">
+        <h3 class="panel-title">Payflow Pro</h3>
+      </div>
+      <div class="panel-body">
+        {{#autoForm
+          collection="ReactionCore.Collections.Packages"
+          schema=PaypalPackageConfig
+          doc=packageData
+          type="update"
+          id="paypal-update-form-payflow"
         }}
 
-        <div class="form-group">
-          Don't have a PayPal client ID and secret? <a href="https://developer.paypal.com/webapps/developer/applications" target="_blank">Get them here.</a>
-        </div>
-        {{>afQuickField name='settings.payflow_enabled' type="boolean-select" trueLabel="Enabled" falseLabel="Disabled" style="width: auto"}}
-        {{>afQuickField name='settings.client_id'}}
-        {{>afQuickField name='settings.client_secret' type="password"}}
-        {{>afQuickField name='settings.payflow_mode' type="boolean-select" trueLabel="Live - Production Mode" falseLabel="Testing - Sandbox Mode" style="width: auto"}}
-        <button type="submit" class="btn btn-primary pull-right">Save Changes</button>
-      {{/autoForm}}
+          <div class="form-group">
+            Don't have a PayPal client ID and secret? <a
+              href="https://developer.paypal.com/webapps/developer/applications" target="_blank">Get them here.</a>
+          </div>
+          {{>afQuickField name='settings.payflow_enabled' type="boolean-select" trueLabel="Enabled" falseLabel="Disabled" style="width: auto"}}
+          {{>afQuickField name='settings.client_id'}}
+          {{>afQuickField name='settings.client_secret' type="password"}}
+          {{>afQuickField name='settings.payflow_mode' type="boolean-select" trueLabel="Live - Production Mode" falseLabel="Testing - Sandbox Mode" style="width: auto" }}
+          <button type="submit" class="btn btn-primary pull-right">Save Changes</button>
+        {{/autoForm}}
+      </div>
     </div>
   </div>
-
-
 </template>

--- a/imports/plugins/included/paypal/client/templates/settings/settings.js
+++ b/imports/plugins/included/paypal/client/templates/settings/settings.js
@@ -1,6 +1,6 @@
 /* eslint camelcase: 0 */
 import { Template } from "meteor/templating";
-import { Packages } from "/lib/collections";
+import { Packages, Accounts } from "/lib/collections";
 import { PaypalPackageConfig } from "../../../lib/collections/schemas";
 
 Template.paypalSettings.helpers({
@@ -27,4 +27,27 @@ AutoForm.hooks({
       return Alerts.add("Paypal settings update failed. " + error, "danger");
     }
   }
+});
+
+Template.paypalSettings.events({
+  'mouseenter .paypalTour'(){
+
+    const currentUser = Accounts.findOne(Meteor.userId());
+    const myintro = introJs("#paypal-config");
+
+    if(!currentUser.paypalSettingsTour){
+      myintro.start();
+    }
+
+    myintro.oncomplete(function() { 
+      Accounts.update({_id: Meteor.userId()}, {$set:{paypalSettingsTour: true}}, function (error, res) {
+      });
+        
+    });
+  },
+
+  'mouseleave .paypalTour'(){
+     const myintro = introJs("#paypal-config");
+     myintro.exit();
+  },
 });

--- a/imports/plugins/included/product-variant/client/templates/products/productGrid/productGrid.html
+++ b/imports/plugins/included/product-variant/client/templates/products/productGrid/productGrid.html
@@ -1,7 +1,7 @@
 <template name="productGrid">
   <div class="container-main">
     <div class="product-grid">
-      <ul class="product-grid-list list-unstyled" id="product-grid-list" data-step="10" data-intro="Thrse are they available products">
+      <ul class="product-grid-list list-unstyled" id="product-grid-list" data-step="10" data-intro="These are they available products">
         {{#each products}}
           {{> productGridItems}}
         {{else}}

--- a/lib/collections/schemas/accounts.js
+++ b/lib/collections/schemas/accounts.js
@@ -88,6 +88,21 @@ export const Accounts = new SimpleSchema({
     optional: true,
     defaultValue: false
   },
+  shopSettingsTour: {
+    type: Boolean,
+    optional: true,
+    defaultValue: false
+  },
+  i18nSettingsTour: {
+    type: Boolean,
+    optional: true,
+    defaultValue: false
+  },
+  paypalSettingsTour: {
+    type: Boolean,
+    optional: true,
+    defaultValue: false
+  },
   profile: {
     type: Profile,
     optional: true

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "react": "^15.3.2",
     "react-addons-create-fragment": "^15.3.2",
     "react-addons-pure-render-mixin": "^15.3.2",
+    "react-addons-shallow-compare": "^15.4.1",
     "react-autosuggest": "^6.0.4",
     "react-bootstrap": "^0.30.5",
     "react-color": "^2.3.2",


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->
**Are you submitting to `develop`?**
Yes
We currently only accept PR's to `develop` not `master`

#[#134061759] Extension of  the tour to three complicated settings on the dashboard

#### What does this PR do?
It moves the take tour button on the navigation bar into the accounts dropdown
It extends the tour to the shop, i18n and Paypal settings
The tour starts automatically on user's first visit to any of these settings